### PR TITLE
Implement support for &lt; and &gt; entities (#15)

### DIFF
--- a/python/http.py
+++ b/python/http.py
@@ -3,6 +3,7 @@ import socket
 import ssl
 import sys
 import zlib
+from enum import Enum
 
 try:
     import brotli
@@ -125,6 +126,10 @@ def decompress(data, encoding):
     else:
         raise RuntimeError(f"unexpected content-encoding: {encoding}")
 
+class LexState(Enum):
+    TEXT = 0
+    ANGLE = 1
+    ESCAPE = 2
 
 def lex(body):
     # TODO: Will be removed in future course.
@@ -139,13 +144,24 @@ def lex(body):
 
     # TODO: This logic will be removed in future course.
     body = get_body(body)
-    text = ""
-    in_angle = False
+    text, escape = "", ""
+    state = LexState.TEXT
     for c in body:
         if c == "<":
-            in_angle = True
+            state = LexState.ANGLE
         elif c == ">":
-            in_angle = False
-        elif not in_angle:
+            state = LexState.TEXT
+        elif c == "&":
+            state = LexState.ESCAPE
+        elif c == ";":
+            state = LexState.TEXT
+            if escape == "lt":
+                text += "<"
+            elif escape == "gt":
+                text += ">"
+            escape = ""
+        elif state == LexState.ESCAPE:
+            escape += c
+        elif state == LexState.TEXT:
             text += c
     return text

--- a/python/http.py
+++ b/python/http.py
@@ -126,10 +126,12 @@ def decompress(data, encoding):
     else:
         raise RuntimeError(f"unexpected content-encoding: {encoding}")
 
+
 class LexState(Enum):
     TEXT = 0
     ANGLE = 1
     ESCAPE = 2
+
 
 def lex(body):
     # TODO: Will be removed in future course.

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -32,6 +32,11 @@ class RequestTest(unittest.TestCase):
         ret = lex(origin)
         self.assertEqual(ret, " test ")
 
+    def test_lex_with_escape(self):
+        origin = "&lt;div&gt;abc&lt;/div&gt;"
+        ret = lex(origin)
+        self.assertEqual(ret, "<div>abc</div>")
+
     def test_redirect(self):
         redirect_sites = [
             "http://www.naver.com/",

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod http {
     use std::collections::HashMap;
-    use std::str;
     use std::env;
     use std::io::{self, BufRead, BufReader, Read, Write};
     use std::net::TcpStream;
+    use std::str;
     use std::sync::Arc;
 
     use flate2::bufread::{DeflateDecoder, GzDecoder};
@@ -284,18 +284,16 @@ pub mod http {
                     match sign {
                         "lt" => out.push(b'<'),
                         "gt" => out.push(b'>'),
-                        _ => {},
+                        _ => {}
                     }
                     escape = Vec::new();
                     state = LexState::Text;
-                },
-                _ => {
-                    match state {
-                        LexState::Text => out.push(*c),
-                        LexState::Escape => escape.push(*c),
-                        LexState::Angle => {},
-                    }
                 }
+                _ => match state {
+                    LexState::Text => out.push(*c),
+                    LexState::Escape => escape.push(*c),
+                    LexState::Angle => {}
+                },
             }
         }
         String::from_utf8(out).expect("utf-8 website is expected")


### PR DESCRIPTION
- Implement support for the less-than (&lt;) and greater-than (&gt;) entities
  - Check escape sign `&` and `;`
  - Manage state with Enum value `state`
- Support Python and Rust both